### PR TITLE
Set correct filetype for kittens image

### DIFF
--- a/examples/3-06/pictureAlternativeFormats/index.html
+++ b/examples/3-06/pictureAlternativeFormats/index.html
@@ -21,7 +21,7 @@
 
   <picture>
     <source srcset="kittens.webp" type="image/webp">
-    <source srcset="kittens.jpeg" type="image/jpeg">
+    <source srcset="kittens.jpg" type="image/jpeg">
     <img src="kittens.jpg" alt="Two grey tabby kittens">
   </picture>
 


### PR DESCRIPTION
There is no kittens.jpeg file in directory, so changed filetype to jpg. The page was displayed incorrectly in browsers, that don't support webp format.
